### PR TITLE
Add dependency to fix kotlinx unresolved reference error. Update version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '0.11.91.1'
+    ext.kotlin_version = '0.12.613'
     repositories {
         jcenter()
     }
@@ -9,6 +9,8 @@ buildscript {
         classpath 'com.android.tools.build:gradle:1.1.3'
         //kotlin required plugin
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        //Kotlin Extensions for Android required plugin
+        classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlin_version"
         //Dagger 2 required plugin
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
     }


### PR DESCRIPTION
Add dependency for Kotlin Extensions for Android plugin to fix unresolved reference
error in MainActivity.kt -- import statement: kotlinx

Update Kotlin to version M12.1 to fix build errors in MainActivity.kt -- assert method