### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ This project demonstrate how to setup an Android Project with Kotlin and Dagger 
 
 It's based on Dagger 2 [example](https://github.com/google/dagger/tree/master/examples/android-simple)
 
-##Known issues/limitations
+## Known issues/limitations
 
 When `lateinit` modifier is used, your variable cannot be used in `init{}` block. It will not compile. So in that case I suggest to move code from that block into a separate function and then call that function from `init{}` block.
 
-##More than Dagger
+## More than Dagger
 
 This sample project includes some more dependencies which are very usefull. It's like a base setup for almost every project using Kotlin.
 So you will find there Anko libraries. You can uncomment Anko's DSL libraries if you need them.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
